### PR TITLE
Add monthly budget history navigation

### DIFF
--- a/ineat-backend/src/budget/controllers/budget.controller.spec.ts
+++ b/ineat-backend/src/budget/controllers/budget.controller.spec.ts
@@ -1,0 +1,80 @@
+import { BadRequestException } from '@nestjs/common';
+import { Request } from 'express';
+import { BudgetController } from './budget.controller';
+
+describe('BudgetController', () => {
+  const budgetService = {
+    getBudgetByMonth: jest.fn(),
+    getBudgetStats: jest.fn(),
+  };
+  const expenseService = {
+    getBudgetExpenses: jest.fn(),
+  };
+
+  const request = {
+    user: { id: 'user-1' },
+  } as unknown as Request;
+
+  let controller: BudgetController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new BudgetController(
+      budgetService as any,
+      expenseService as any,
+    );
+  });
+
+  it.each(['2026-00', '2026-13', 'avril-2026', '2026-4'])(
+    'rejects the invalid month %s',
+    async (month) => {
+      await expect(
+        controller.getBudgetByMonth(request, month),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(budgetService.getBudgetByMonth).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns an explicit empty response when the month has no budget', async () => {
+    budgetService.getBudgetByMonth.mockResolvedValue(null);
+
+    await expect(
+      controller.getBudgetByMonth(request, '2026-04'),
+    ).resolves.toEqual({
+      success: true,
+      data: null,
+      message: 'Aucun budget défini pour ce mois',
+    });
+    expect(budgetService.getBudgetByMonth).toHaveBeenCalledWith(
+      'user-1',
+      2026,
+      3,
+    );
+    expect(budgetService.getBudgetStats).not.toHaveBeenCalled();
+    expect(expenseService.getBudgetExpenses).not.toHaveBeenCalled();
+  });
+
+  it('returns the budget, its stats and its expenses for the requested month', async () => {
+    const budget = { id: 'budget-april', isActive: false };
+    const stats = { totalBudget: 450, totalSpent: 120 };
+    const expenses = [{ id: 'expense-1', budgetId: budget.id, amount: 12 }];
+    budgetService.getBudgetByMonth.mockResolvedValue(budget);
+    budgetService.getBudgetStats.mockResolvedValue(stats);
+    expenseService.getBudgetExpenses.mockResolvedValue(expenses);
+
+    await expect(
+      controller.getBudgetByMonth(request, '2026-04'),
+    ).resolves.toEqual({
+      success: true,
+      data: { budget, stats, expenses, alerts: [] },
+    });
+    expect(budgetService.getBudgetStats).toHaveBeenCalledWith(
+      budget.id,
+      'user-1',
+    );
+    expect(expenseService.getBudgetExpenses).toHaveBeenCalledWith(
+      budget.id,
+      'user-1',
+    );
+  });
+});

--- a/ineat-backend/src/budget/controllers/budget.controller.ts
+++ b/ineat-backend/src/budget/controllers/budget.controller.ts
@@ -150,10 +150,7 @@ export class BudgetController {
    * GET /budget/month/:month
    */
   @Get('month/:month')
-  async getBudgetByMonth(
-    @Req() req: Request,
-    @Param('month') month: string,
-  ) {
+  async getBudgetByMonth(@Req() req: Request, @Param('month') month: string) {
     try {
       if (!/^\d{4}-\d{2}$/.test(month)) {
         throw new BadRequestException('Le mois doit être au format YYYY-MM');
@@ -161,20 +158,39 @@ export class BudgetController {
 
       const userId = (req.user as { id: string }).id;
       const [year, monthNumber] = month.split('-').map(Number);
-      const monthStart = new Date(year, monthNumber - 1, 1, 0, 0, 0, 0);
-      const monthEnd = new Date(year, monthNumber, 0, 23, 59, 59, 999);
-      const budgets = await this.budgetService.getBudgets(userId);
-      const budget =
-        budgets.find(
-          (candidate) =>
-            candidate.periodStart <= monthEnd &&
-            candidate.periodEnd >= monthStart &&
-            candidate.isActive,
-        ) || null;
+      if (monthNumber < 1 || monthNumber > 12) {
+        throw new BadRequestException(
+          'Le mois doit être compris entre 01 et 12',
+        );
+      }
+
+      const budget = await this.budgetService.getBudgetByMonth(
+        userId,
+        year,
+        monthNumber - 1,
+      );
+
+      if (!budget) {
+        return {
+          success: true,
+          data: null,
+          message: 'Aucun budget défini pour ce mois',
+        };
+      }
+
+      const [stats, expenses] = await Promise.all([
+        this.budgetService.getBudgetStats(budget.id, userId),
+        this.expenseService.getBudgetExpenses(budget.id, userId),
+      ]);
 
       return {
         success: true,
-        data: budget,
+        data: {
+          budget,
+          stats,
+          expenses,
+          alerts: [],
+        },
       };
     } catch (error) {
       if (error instanceof BadRequestException) {

--- a/ineat-backend/src/budget/services/budget.service.spec.ts
+++ b/ineat-backend/src/budget/services/budget.service.spec.ts
@@ -41,6 +41,29 @@ describe('BudgetService', () => {
     });
   });
 
+  it('finds a historical budget by month without requiring it to be active', async () => {
+    const historicalBudget = {
+      id: 'budget-april',
+      userId: 'user-1',
+      isActive: false,
+    };
+    prisma.budget.findFirst.mockResolvedValue(historicalBudget);
+
+    const result = await service.getBudgetByMonth('user-1', 2026, 3);
+
+    expect(result).toBe(historicalBudget);
+    expect(prisma.budget.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        periodStart: { lte: new Date(2026, 4, 0, 23, 59, 59, 999) },
+        periodEnd: { gte: new Date(2026, 3, 1, 0, 0, 0, 0) },
+      },
+      orderBy: { periodStart: 'desc' },
+    });
+    expect(prisma.budget.create).not.toHaveBeenCalled();
+    expect(prisma.budget.updateMany).not.toHaveBeenCalled();
+  });
+
   it('normalizes updated period boundaries', async () => {
     prisma.budget.findFirst.mockResolvedValue({
       id: 'budget-1',

--- a/ineat-backend/src/budget/services/budget.service.ts
+++ b/ineat-backend/src/budget/services/budget.service.ts
@@ -185,6 +185,27 @@ export class BudgetService {
   }
 
   /**
+   * Récupère le budget qui couvre un mois donné, sans créer ni modifier de budget.
+   */
+  async getBudgetByMonth(
+    userId: string,
+    year: number,
+    month: number,
+  ): Promise<Budget | null> {
+    const monthStart = new Date(year, month, 1, 0, 0, 0, 0);
+    const monthEnd = new Date(year, month + 1, 0, 23, 59, 59, 999);
+
+    return this.prisma.budget.findFirst({
+      where: {
+        userId,
+        periodStart: { lte: monthEnd },
+        periodEnd: { gte: monthStart },
+      },
+      orderBy: { periodStart: 'desc' },
+    });
+  }
+
+  /**
    * Récupère un budget par son ID
    */
   async getBudgetById(

--- a/ineat-backend/src/recipe/services/recipe.service.ts
+++ b/ineat-backend/src/recipe/services/recipe.service.ts
@@ -286,12 +286,20 @@ export class RecipeService {
     }
 
     const requestedTypes = new Set(request.types);
+    const generatedTypes = new Set<GeneratedRecipePayloadDto['type']>();
     const inventoryIds = new Set(inventory.map((item) => item.productId));
 
     for (const recipe of recipes) {
       if (!requestedTypes.has(recipe.type)) {
         throw new BadRequestException('Une recette générée a un type invalide');
       }
+
+      if (generatedTypes.has(recipe.type)) {
+        throw new BadRequestException(
+          'La génération contient plusieurs recettes du même type',
+        );
+      }
+      generatedTypes.add(recipe.type);
 
       const missingIngredients = recipe.ingredients.filter(
         (ingredient) => ingredient.source === 'MISSING',

--- a/ineat-frontend/src/features/inventory/form/ExistingProductQuickAddForm.tsx
+++ b/ineat-frontend/src/features/inventory/form/ExistingProductQuickAddForm.tsx
@@ -265,8 +265,9 @@ export const ExistingProductQuickAddForm: React.FC<
 		setExpiryDateSource(value ? 'MANUAL' : 'ESTIMATED');
 		if (errors.expiryDate) {
 			setErrors((prev) => {
-				const { expiryDate: _removed, ...rest } = prev;
-				return rest;
+				const nextErrors = { ...prev };
+				delete nextErrors.expiryDate;
+				return nextErrors;
 			});
 		}
 	};

--- a/ineat-frontend/src/features/inventory/form/QuickAddForm.tsx
+++ b/ineat-frontend/src/features/inventory/form/QuickAddForm.tsx
@@ -260,8 +260,9 @@ export const QuickAddForm: React.FC<QuickAddFormProps> = ({
 		setExpiryDateSource(value ? 'MANUAL' : 'ESTIMATED');
 		if (errors.expiryDate) {
 			setErrors((prev) => {
-				const { expiryDate: _removed, ...rest } = prev;
-				return rest;
+				const nextErrors = { ...prev };
+				delete nextErrors.expiryDate;
+				return nextErrors;
 			});
 		}
 	};

--- a/ineat-frontend/src/lib/api-client.ts
+++ b/ineat-frontend/src/lib/api-client.ts
@@ -31,7 +31,6 @@ const NETWORK_ERROR_MESSAGE =
 	'Impossible de joindre le serveur. Vérifiez votre connexion.';
 
 interface FetchOptions extends RequestInit {
-	skipAuth?: boolean;
 	timeoutMs?: number;
 }
 
@@ -150,12 +149,7 @@ const getPublicErrorMessage = (
 export const apiClient = {
 	// Méthode principale pour effectuer des requêtes
 	async fetch<T>(endpoint: string, options: FetchOptions = {}): Promise<T> {
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const {
-			skipAuth = false,
-			timeoutMs = DEFAULT_TIMEOUT_MS,
-			...fetchOptions
-		} = options;
+		const { timeoutMs = DEFAULT_TIMEOUT_MS, ...fetchOptions } = options;
 
 		const isFormData = fetchOptions.body instanceof FormData;
 

--- a/ineat-frontend/src/pages/budget/BudgetPage.test.tsx
+++ b/ineat-frontend/src/pages/budget/BudgetPage.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BudgetPage } from './BudgetPage';
+
+const navigate = vi.fn();
+const setSelectedMonth = vi.fn();
+let search: { month?: string } = {};
+let budgetState: Record<string, unknown>;
+
+vi.mock('@tanstack/react-router', () => ({
+	Link: ({ children, to }: { children: ReactNode; to: string }) => (
+		<a href={to}>{children}</a>
+	),
+	useNavigate: () => navigate,
+	useSearch: () => search,
+}));
+
+vi.mock('@/stores/budgetStore', () => ({
+	useBudgetStore: () => budgetState,
+}));
+
+vi.mock('@/features/budget/BudgetEditor', () => ({
+	default: () => <div data-testid='create-budget'>Créer un budget</div>,
+}));
+
+vi.mock('@/features/budget/EditBudgetDialog', () => ({
+	default: () => <div data-testid='edit-budget'>Modifier le budget</div>,
+}));
+
+vi.mock('@/features/budget/BudgetStatsCard', () => ({
+	default: () => <div data-testid='budget-stats'>Statistiques</div>,
+}));
+
+vi.mock('@/features/budget/BudgetAlert', () => ({
+	default: () => <div data-testid='budget-alerts'>Alertes</div>,
+}));
+
+vi.mock('@/features/budget/ExpenseList', () => ({
+	default: () => <div data-testid='expense-list'>Dépenses</div>,
+}));
+
+const budget = {
+	id: '11111111-1111-4111-8111-111111111111',
+	userId: '22222222-2222-4222-8222-222222222222',
+	amount: 450,
+	periodStart: '2026-04-01T00:00:00.000Z',
+	periodEnd: '2026-04-30T23:59:59.999Z',
+	isActive: false,
+	createdAt: '2026-04-01T00:00:00.000Z',
+	updatedAt: '2026-04-30T23:59:59.999Z',
+};
+
+const stats = {
+	totalBudget: 450,
+	totalSpent: 120,
+	remaining: 330,
+	percentageUsed: 26.67,
+	projectedSpending: 120,
+	daysRemaining: 0,
+	averageDailySpending: 4,
+	suggestedDailyBudget: 0,
+	isOverBudget: false,
+	isNearBudget: false,
+	riskLevel: 'LOW',
+	categoryBreakdown: [],
+	sourceBreakdown: [],
+	dailySpending: [],
+};
+
+describe('BudgetPage monthly navigation', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(2026, 6, 24, 12));
+		vi.clearAllMocks();
+		search = {};
+		budgetState = {
+			selectedBudget: budget,
+			selectedBudgetStats: stats,
+			selectedAlerts: [],
+			selectedExpenses: [],
+			isLoading: false,
+			isLoadingExpenses: false,
+			error: null,
+			setSelectedMonth,
+		};
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('shows the current month with editing enabled and future navigation disabled', () => {
+		render(<BudgetPage />);
+
+		expect(setSelectedMonth).toHaveBeenCalledWith('2026-07');
+		expect(screen.getByText('Juillet 2026')).toBeInTheDocument();
+		expect(screen.getByTestId('edit-budget')).toBeInTheDocument();
+		expect(screen.getByTestId('budget-alerts')).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Afficher le mois suivant' })
+		).toBeDisabled();
+	});
+
+	it('shows a past month read-only and navigates through the URL', () => {
+		search = { month: '2026-04' };
+		render(<BudgetPage />);
+
+		expect(setSelectedMonth).toHaveBeenCalledWith('2026-04');
+		expect(screen.getByText('Avril 2026')).toBeInTheDocument();
+		expect(screen.queryByTestId('edit-budget')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('budget-alerts')).not.toBeInTheDocument();
+		expect(screen.getByTestId('expense-list')).toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'Afficher le mois suivant' })
+		);
+		expect(navigate).toHaveBeenCalledWith({
+			to: '/app/budget',
+			search: { month: '2026-05' },
+		});
+	});
+
+	it('shows an historical empty state without offering budget creation', () => {
+		search = { month: '2026-04' };
+		budgetState = {
+			...budgetState,
+			selectedBudget: null,
+			selectedBudgetStats: null,
+		};
+
+		render(<BudgetPage />);
+
+		expect(
+			screen.getByText('Aucun budget enregistré en avril 2026')
+		).toBeInTheDocument();
+		expect(screen.queryByTestId('create-budget')).not.toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'Revenir au mois courant' })
+		).toBeInTheDocument();
+	});
+});

--- a/ineat-frontend/src/pages/budget/BudgetPage.tsx
+++ b/ineat-frontend/src/pages/budget/BudgetPage.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useMemo, useCallback } from 'react';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 
 import CreateBudget from '@/features/budget/BudgetEditor';
 import EditBudgetDialog from '@/features/budget/EditBudgetDialog';
@@ -16,43 +16,87 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
-import { AlertTriangle, Loader2, ArrowLeft } from 'lucide-react';
+import {
+	AlertTriangle,
+	Loader2,
+	ArrowLeft,
+	ChevronLeft,
+	ChevronRight,
+} from 'lucide-react';
+
+const getCurrentMonth = () => {
+	const now = new Date();
+	return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+};
+
+const shiftMonth = (month: string, offset: number) => {
+	const [year, monthNumber] = month.split('-').map(Number);
+	const date = new Date(year, monthNumber - 1 + offset, 1);
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+};
+
+const formatMonth = (month: string) => {
+	const [year, monthNumber] = month.split('-').map(Number);
+	const label = new Intl.DateTimeFormat('fr-FR', {
+		month: 'long',
+		year: 'numeric',
+	}).format(new Date(year, monthNumber - 1, 1));
+	return label.charAt(0).toUpperCase() + label.slice(1);
+};
 
 export const BudgetPage: FC = () => {
+	const navigate = useNavigate();
+	const search = useSearch({ from: '/app/budget/' });
+	const currentMonth = getCurrentMonth();
+	const displayedMonth = search.month || currentMonth;
+	const isCurrentMonth = displayedMonth === currentMonth;
 	const {
-		currentBudget,
-		budgetStats,
-		alerts,
-		expenses,
+		selectedBudget,
+		selectedBudgetStats,
+		selectedAlerts,
+		selectedExpenses,
 		isLoading,
 		isLoadingExpenses,
 		error,
-		fetchCurrentBudget,
+		setSelectedMonth,
 	} = useBudgetStore();
 
 	const safeBudgetPeriod = useMemo(() => {
-		if (!currentBudget) {
+		if (!selectedBudget) {
 			return null;
 		}
 
-		if (!isValidBudget(currentBudget)) {
+		if (!isValidBudget(selectedBudget)) {
 			return 'Budget invalide';
 		}
 
 		try {
-			return budgetService.formatBudgetPeriod(currentBudget);
+			return budgetService.formatBudgetPeriod(selectedBudget);
 		} catch {
 			return 'Erreur de formatage';
 		}
-	}, [currentBudget]);
+	}, [selectedBudget]);
 
 	const handleBudgetCreated = useCallback(() => {
-		fetchCurrentBudget();
-	}, [fetchCurrentBudget]);
+		setSelectedMonth(currentMonth);
+	}, [currentMonth, setSelectedMonth]);
 
 	useEffect(() => {
-		fetchCurrentBudget();
-	}, [fetchCurrentBudget]);
+		setSelectedMonth(displayedMonth);
+	}, [displayedMonth, setSelectedMonth]);
+
+	const selectMonth = useCallback(
+		(month: string) => {
+			if (month > currentMonth) {
+				return;
+			}
+			navigate({
+				to: '/app/budget',
+				search: month === currentMonth ? {} : { month },
+			});
+		},
+		[currentMonth, navigate]
+	);
 
 	return (
 		<div className='min-h-screen bg-gradient-to-br from-gray-50 to-blue-50/30'>
@@ -73,18 +117,22 @@ export const BudgetPage: FC = () => {
 						<div>
 							<h1 className='text-2xl font-bold text-gray-900'>
 								Budget{' '}
-								{safeBudgetPeriod || 'Période non disponible'}
+								{safeBudgetPeriod || formatMonth(displayedMonth)}
 							</h1>
 							<p className='text-sm text-gray-600'>
-								Suivi de vos dépenses
+								{isCurrentMonth
+									? 'Suivi de vos dépenses'
+									: 'Consultation d’un mois passé'}
 							</p>
 						</div>
 					</div>
 
-					{currentBudget && isValidBudget(currentBudget) && (
+					{isCurrentMonth &&
+						selectedBudget &&
+						isValidBudget(selectedBudget) && (
 						<div className='flex items-center gap-4'>
 							<EditBudgetDialog
-								budget={currentBudget}
+								budget={selectedBudget}
 								onBudgetUpdated={handleBudgetCreated}
 							/>
 						</div>
@@ -93,6 +141,31 @@ export const BudgetPage: FC = () => {
 			</div>
 
 			<div className='max-w-7xl mx-auto p-6 space-y-6'>
+				<div className='flex flex-wrap items-center justify-center gap-3'>
+					<Button
+						variant='outline'
+						size='sm'
+						aria-label='Afficher le mois précédent'
+						onClick={() => selectMonth(shiftMonth(displayedMonth, -1))}>
+						<ChevronLeft className='size-4' />
+					</Button>
+					<div className='min-w-40 text-center font-semibold text-gray-900'>
+						{formatMonth(displayedMonth)}
+					</div>
+					<Button
+						variant='outline'
+						size='sm'
+						aria-label='Afficher le mois suivant'
+						disabled={displayedMonth >= currentMonth}
+						onClick={() => selectMonth(shiftMonth(displayedMonth, 1))}>
+						<ChevronRight className='size-4' />
+					</Button>
+					{!isCurrentMonth && (
+						<Button size='sm' onClick={() => selectMonth(currentMonth)}>
+							Revenir au mois courant
+						</Button>
+					)}
+				</div>
 				{error && (
 					<Alert variant='warning'>
 						<AlertTriangle className='size-4' />
@@ -111,19 +184,32 @@ export const BudgetPage: FC = () => {
 							</div>
 						</CardContent>
 					</Card>
-				) : !currentBudget ||
-				  !budgetStats ||
-				  !isValidBudget(currentBudget) ? (
-					<CreateBudget onBudgetCreated={handleBudgetCreated} />
+				) : !selectedBudget ||
+				  !selectedBudgetStats ||
+				  !isValidBudget(selectedBudget) ? (
+					isCurrentMonth ? (
+						<CreateBudget onBudgetCreated={handleBudgetCreated} />
+					) : (
+						<Card>
+							<CardContent className='py-12 text-center space-y-2'>
+								<h2 className='text-lg font-semibold text-gray-900'>
+									Aucun budget enregistré en {formatMonth(displayedMonth).toLowerCase()}
+								</h2>
+								<p className='text-sm text-gray-600'>
+									Vous pouvez consulter un autre mois ou revenir au mois courant.
+								</p>
+							</CardContent>
+						</Card>
+					)
 				) : (
 					<div className='space-y-6'>
-						<BudgetAlerts alerts={alerts} />
+						{isCurrentMonth && <BudgetAlerts alerts={selectedAlerts} />}
 						<BudgetStatsCards
-							budget={currentBudget}
-							stats={budgetStats}
+							budget={selectedBudget}
+							stats={selectedBudgetStats}
 						/>
 						<ExpenseList
-							expenses={expenses}
+							expenses={selectedExpenses}
 							isLoading={isLoadingExpenses}
 						/>
 					</div>

--- a/ineat-frontend/src/pages/recipes/RecipeDetailPage.test.tsx
+++ b/ineat-frontend/src/pages/recipes/RecipeDetailPage.test.tsx
@@ -161,7 +161,7 @@ describe('RecipeDetailPage', () => {
 		);
 
 		expect(
-			await screen.findByRole('dialog', {
+			await screen.findByRole('alertdialog', {
 				name: /marquer la recette comme faite/i,
 			})
 		).toBeInTheDocument();
@@ -185,7 +185,7 @@ describe('RecipeDetailPage', () => {
 			).toBeDisabled();
 		});
 		expect(
-			screen.queryByRole('dialog', {
+			screen.queryByRole('alertdialog', {
 				name: /marquer la recette comme faite/i,
 			})
 		).not.toBeInTheDocument();

--- a/ineat-frontend/src/routes/app/budget/index.tsx
+++ b/ineat-frontend/src/routes/app/budget/index.tsx
@@ -1,7 +1,13 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { BudgetPage } from '@/pages/budget/BudgetPage'
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { BudgetPage } from '@/pages/budget/BudgetPage';
+
+const monthSchema = z
+	.string()
+	.regex(/^\d{4}-(0[1-9]|1[0-2])$/)
+	.optional();
 
 export const Route = createFileRoute('/app/budget/')({
-  component: BudgetPage,
-})
-
+	component: BudgetPage,
+	validateSearch: z.object({ month: monthSchema }),
+});

--- a/ineat-frontend/src/services/budgetService.test.ts
+++ b/ineat-frontend/src/services/budgetService.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import { budgetService } from './budgetService';
+import { server } from '@/test/mocks/server';
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+const budget = {
+	id: '11111111-1111-4111-8111-111111111111',
+	userId: '22222222-2222-4222-8222-222222222222',
+	amount: 450,
+	periodStart: '2026-04-01T00:00:00.000Z',
+	periodEnd: '2026-04-30T23:59:59.999Z',
+	isActive: false,
+	createdAt: '2026-04-01T00:00:00.000Z',
+	updatedAt: '2026-04-30T23:59:59.999Z',
+};
+
+const stats = {
+	totalBudget: 450,
+	totalSpent: 120,
+	remaining: 330,
+	percentageUsed: 26.67,
+	projectedSpending: 120,
+	daysRemaining: 0,
+	averageDailySpending: 4,
+	suggestedDailyBudget: 0,
+	isOverBudget: false,
+	isNearBudget: false,
+	riskLevel: 'LOW' as const,
+	categoryBreakdown: [],
+	sourceBreakdown: [],
+	dailySpending: [],
+};
+
+describe('budgetService', () => {
+	it('récupère toutes les données du budget pour un mois historique', async () => {
+		server.use(
+			http.get(`${API_URL}/budget/month/2026-04`, () =>
+				HttpResponse.json({
+					success: true,
+					data: { budget, stats, expenses: [], alerts: [] },
+				})
+			),
+		);
+
+		const result = await budgetService.getBudgetByMonth('2026-04');
+
+		expect(result).toMatchObject({
+			budget: { id: budget.id, isActive: false },
+			stats: { totalSpent: 120, daysRemaining: 0 },
+			expenses: [],
+			alerts: [],
+		});
+	});
+
+	it('retourne null lorsqu’aucun budget n’existe pour le mois', async () => {
+		server.use(
+			http.get(`${API_URL}/budget/month/2026-03`, () =>
+				HttpResponse.json({ success: true, data: null })
+			),
+		);
+
+		await expect(
+			budgetService.getBudgetByMonth('2026-03')
+		).resolves.toBeNull();
+	});
+});

--- a/ineat-frontend/src/services/budgetService.ts
+++ b/ineat-frontend/src/services/budgetService.ts
@@ -211,26 +211,36 @@ export const budgetService = {
 		return processBudgetResponse(response);
 	},
 
-	async getBudgetByMonth(month: string): Promise<Budget | null> {
+	async getBudgetByMonth(month: string): Promise<BudgetWithStats | null> {
 		try {
 			const response = await apiClient.get<
-				ApiDataResponse<Budget | RawBudgetApiData | null>
+				ApiDataResponse<BudgetWithStats | null>
 			>(
 				`/budget/month/${month}`
 			);
-			const budget = unwrapApiData(response);
+			const data = unwrapApiData(response);
 
-			if (budget && !isValidBudget(budget as Budget)) {
-				return transformBudgetFromApi(budget as RawBudgetApiData);
+			if (!data) {
+				return null;
 			}
 
-			return budget as Budget | null;
+			let budget = data.budget;
+			if (budget && !isValidBudget(budget)) {
+				budget = transformBudgetFromApi(budget as RawBudgetApiData);
+			}
+
+			return {
+				budget: budget || null,
+				stats: data.stats || null,
+				alerts: data.alerts || [],
+				expenses: data.expenses || [],
+			};
 		} catch (error: unknown) {
 			const err = error as { status?: number };
 			if (err.status === 404) {
 				return null;
 			}
-			return null;
+			throw error;
 		}
 	},
 

--- a/ineat-frontend/src/stores/budgetStore.test.ts
+++ b/ineat-frontend/src/stores/budgetStore.test.ts
@@ -1,0 +1,127 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest';
+
+import { budgetService, BudgetWithStats } from '@/services/budgetService';
+
+let useBudgetStore: typeof import('./budgetStore').useBudgetStore;
+
+const makeBudgetData = (id: string, month: string): BudgetWithStats => ({
+	budget: {
+		id,
+		userId: '22222222-2222-4222-8222-222222222222',
+		amount: 450,
+		periodStart: `${month}-01T00:00:00.000Z`,
+		periodEnd: `${month}-28T23:59:59.999Z`,
+		isActive: false,
+		createdAt: `${month}-01T00:00:00.000Z`,
+		updatedAt: `${month}-28T23:59:59.999Z`,
+	},
+	stats: {
+		totalBudget: 450,
+		totalSpent: 120,
+		remaining: 330,
+		percentageUsed: 26.67,
+		projectedSpending: 120,
+		daysRemaining: 0,
+		averageDailySpending: 4,
+		suggestedDailyBudget: 0,
+		isOverBudget: false,
+		isNearBudget: false,
+		riskLevel: 'LOW',
+		categoryBreakdown: [],
+		sourceBreakdown: [],
+		dailySpending: [],
+	},
+	alerts: [],
+	expenses: [],
+});
+
+const deferred = <T>() => {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolver) => {
+		resolve = resolver;
+	});
+	return { promise, resolve };
+};
+
+describe('budgetStore historical selection', () => {
+	beforeAll(async () => {
+		const values = new Map<string, string>();
+		vi.stubGlobal('localStorage', {
+			getItem: (key: string) => values.get(key) ?? null,
+			setItem: (key: string, value: string) => values.set(key, value),
+			removeItem: (key: string) => values.delete(key),
+			clear: () => values.clear(),
+		});
+		({ useBudgetStore } = await import('./budgetStore'));
+	});
+
+	beforeEach(() => {
+		useBudgetStore.getState().resetBudgetStore();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('loads a historical month without replacing the dashboard current budget', async () => {
+		const current = makeBudgetData(
+			'11111111-1111-4111-8111-111111111111',
+			'2026-07'
+		).budget;
+		const april = makeBudgetData(
+			'33333333-3333-4333-8333-333333333333',
+			'2026-04'
+		);
+		useBudgetStore.setState({ currentBudget: current });
+		vi.spyOn(budgetService, 'getBudgetByMonth').mockResolvedValue(april);
+
+		useBudgetStore.getState().setSelectedMonth('2026-04');
+		await vi.waitFor(() => {
+			expect(useBudgetStore.getState().isLoading).toBe(false);
+		});
+
+		expect(useBudgetStore.getState().selectedBudget?.id).toBe(
+			april.budget?.id
+		);
+		expect(useBudgetStore.getState().currentBudget?.id).toBe(current?.id);
+	});
+
+	it('ignores a stale response after the user selects another month', async () => {
+		const marchRequest = deferred<BudgetWithStats | null>();
+		const aprilRequest = deferred<BudgetWithStats | null>();
+		vi.spyOn(budgetService, 'getBudgetByMonth').mockImplementation((month) =>
+			month === '2026-03' ? marchRequest.promise : aprilRequest.promise
+		);
+
+		useBudgetStore.getState().setSelectedMonth('2026-03');
+		useBudgetStore.getState().setSelectedMonth('2026-04');
+		aprilRequest.resolve(
+			makeBudgetData('44444444-4444-4444-8444-444444444444', '2026-04')
+		);
+		await vi.waitFor(() => {
+			expect(useBudgetStore.getState().isLoading).toBe(false);
+		});
+		marchRequest.resolve(
+			makeBudgetData('55555555-5555-4555-8555-555555555555', '2026-03')
+		);
+
+		await vi.waitFor(() => {
+			expect(useBudgetStore.getState().selectedBudget?.id).toBe(
+				'44444444-4444-4444-8444-444444444444'
+			);
+		});
+	});
+});

--- a/ineat-frontend/src/stores/budgetStore.ts
+++ b/ineat-frontend/src/stores/budgetStore.ts
@@ -22,6 +22,9 @@ interface BudgetState {
 
 interface BudgetPageState {
 	selectedBudget: Budget | null;
+	selectedBudgetStats: BudgetStats | null;
+	selectedAlerts: BudgetAlert[];
+	selectedExpenses: Expense[];
 	expenses: Expense[];
 	budgetHistory: Budget[];
 	selectedMonth: string;
@@ -62,6 +65,9 @@ const initialBudgetState: BudgetState = {
 
 const initialBudgetPageState: BudgetPageState = {
 	selectedBudget: null,
+	selectedBudgetStats: null,
+	selectedAlerts: [],
+	selectedExpenses: [],
 	expenses: [],
 	budgetHistory: [],
 	selectedMonth: getMonthString(),
@@ -206,18 +212,33 @@ export const useBudgetStore = create<BudgetStore>()(
 				set({ isLoading: true, error: null });
 
 				try {
-					const budget = await budgetService.getBudgetByMonth(month);
+					const currentMonth = getMonthString();
+					const data =
+						month === currentMonth
+							? await budgetService.getCurrentBudget()
+							: await budgetService.getBudgetByMonth(month);
+
+					if (get().selectedMonth !== month) {
+						return;
+					}
 
 					set({
-						selectedBudget: budget,
+						selectedBudget: data?.budget || null,
+						selectedBudgetStats: data?.stats || null,
+						selectedAlerts: data?.alerts || [],
+						selectedExpenses: data?.expenses || [],
 						selectedMonth: month,
 						isLoading: false,
-						expenses: [],
 					});
 				} catch {
+					if (get().selectedMonth !== month) {
+						return;
+					}
 					set({
 						selectedBudget: null,
-						expenses: [],
+						selectedBudgetStats: null,
+						selectedAlerts: [],
+						selectedExpenses: [],
 						isLoading: false,
 						error: 'Impossible de récupérer le budget pour ce mois',
 					});


### PR DESCRIPTION
## Résumé

- expose les données complètes d’un budget mensuel passé via une lecture sans mutation
- ajoute la navigation par mois sur `/app/budget`, synchronisée dans l’URL
- affiche les mois passés en lecture seule avec un état vide explicite
- protège le store contre les réponses réseau obsolètes
- couvre les flux backend, service frontend, store et page budget

## Validation

- tests backend ciblés : 9/9 réussis
- tests frontend ciblés : 7/7 réussis
- builds backend et frontend réussis
- lint ciblé réussi
- recette manuelle desktop et mobile réussie

## Tests complets

Deux échecs préexistants et indépendants de cette PR restent suivis dans Linear :

- INE-131 : dialogue de confirmation « Marquer comme faite »
- INE-132 : catégories dupliquées sur les recettes générées

Closes INE-126