### PR TITLE
feat: add Stripe customer portal

### DIFF
--- a/ineat-backend/src/billing/billing.controller.ts
+++ b/ineat-backend/src/billing/billing.controller.ts
@@ -22,6 +22,7 @@ import { BillingService } from './billing.service';
 import {
   CheckoutSessionResponseDto,
   CreateCheckoutSessionDto,
+  PortalSessionResponseDto,
 } from './dto/create-checkout-session.dto';
 
 interface AuthenticatedBillingRequest extends Request {
@@ -73,6 +74,37 @@ export class BillingController {
       req.user,
       dto.interval,
     );
+
+    return {
+      success: true,
+      data: session,
+    };
+  }
+
+  @Post('portal')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Créer une session Stripe Customer Portal',
+    description:
+      "Ouvre le portail Stripe pour gérer l'abonnement, les factures, le moyen de paiement et l'annulation.",
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Session Portal créée',
+    type: PortalSessionResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: "Aucun customer Stripe associé à l'utilisateur",
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Authentification requise',
+  })
+  async createPortalSession(
+    @Req() req: AuthenticatedBillingRequest,
+  ): Promise<PortalSessionResponseDto> {
+    const session = await this.billingService.createPortalSession(req.user);
 
     return {
       success: true,

--- a/ineat-backend/src/billing/billing.service.spec.ts
+++ b/ineat-backend/src/billing/billing.service.spec.ts
@@ -23,6 +23,14 @@ describe('BillingService', () => {
         }),
       },
     },
+    billingPortal: {
+      sessions: {
+        create: jest.fn().mockResolvedValue({
+          id: 'bps_test_123',
+          url: 'https://billing.stripe.com/p/session/bps_test_123',
+        }),
+      },
+    },
     subscriptions: {
       retrieve: jest.fn().mockResolvedValue({
         id: 'sub_123',
@@ -53,6 +61,8 @@ describe('BillingService', () => {
           STRIPE_CHECKOUT_SUCCESS_URL:
             'https://ineat.store/app/subscription/success',
           STRIPE_CHECKOUT_CANCEL_URL: 'https://ineat.store/app/subscription',
+          STRIPE_CUSTOMER_PORTAL_RETURN_URL:
+            'https://ineat.store/app/subscription',
         };
 
         return config[key];
@@ -139,6 +149,36 @@ describe('BillingService', () => {
         line_items: [{ price: 'price_yearly', quantity: 1 }],
       }),
     );
+  });
+
+  it('creates a Customer Portal session for an existing Stripe customer', async () => {
+    const { service, stripe } = createService({
+      ...user,
+      stripeCustomerId: 'cus_existing',
+    });
+
+    const session = await service.createPortalSession(user);
+
+    expect(stripe.billingPortal.sessions.create).toHaveBeenCalledWith({
+      customer: 'cus_existing',
+      return_url: 'https://ineat.store/app/subscription',
+    });
+    expect(session).toEqual({
+      id: 'bps_test_123',
+      url: 'https://billing.stripe.com/p/session/bps_test_123',
+    });
+  });
+
+  it('rejects Customer Portal creation when the user has no Stripe customer', async () => {
+    const { service, stripe } = createService({
+      ...user,
+      stripeCustomerId: null,
+    });
+
+    await expect(service.createPortalSession(user)).rejects.toThrow(
+      "Aucun abonnement Stripe n'est encore associé à votre compte.",
+    );
+    expect(stripe.billingPortal.sessions.create).not.toHaveBeenCalled();
   });
 
   it('does not activate Premium from Checkout creation', async () => {

--- a/ineat-backend/src/billing/billing.service.ts
+++ b/ineat-backend/src/billing/billing.service.ts
@@ -74,6 +74,43 @@ export class BillingService {
     };
   }
 
+  async createPortalSession(user: CheckoutUser) {
+    const stripe = this.stripeClientFactory.getClient();
+    const persistedUser = await this.prisma.user.findUnique({
+      where: { id: user.id },
+      select: { stripeCustomerId: true },
+    });
+
+    if (!persistedUser) {
+      throw new NotFoundException('Utilisateur introuvable');
+    }
+
+    if (!persistedUser.stripeCustomerId) {
+      throw new BadRequestException({
+        code: 'STRIPE_CUSTOMER_MISSING',
+        message:
+          "Aucun abonnement Stripe n'est encore associé à votre compte.",
+      });
+    }
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: persistedUser.stripeCustomerId,
+      return_url: this.getRequiredConfig('STRIPE_CUSTOMER_PORTAL_RETURN_URL'),
+    });
+
+    if (!session.url) {
+      throw new InternalServerErrorException({
+        code: 'STRIPE_PORTAL_URL_MISSING',
+        message: "Impossible d'ouvrir la gestion de l'abonnement.",
+      });
+    }
+
+    return {
+      id: session.id,
+      url: session.url,
+    };
+  }
+
   async handleWebhook(signature?: string, rawBody?: Buffer) {
     if (!signature || !rawBody) {
       throw new BadRequestException('Webhook Stripe invalide');

--- a/ineat-backend/src/billing/dto/create-checkout-session.dto.ts
+++ b/ineat-backend/src/billing/dto/create-checkout-session.dto.ts
@@ -31,3 +31,19 @@ export class CheckoutSessionResponseDto {
     url: string;
   };
 }
+
+export class PortalSessionResponseDto {
+  @ApiProperty({ example: true })
+  success: true;
+
+  @ApiProperty({
+    example: {
+      id: 'bps_test_...',
+      url: 'https://billing.stripe.com/p/session/...',
+    },
+  })
+  data: {
+    id: string;
+    url: string;
+  };
+}

--- a/ineat-frontend/src/pages/settings/SettingsPage.tsx
+++ b/ineat-frontend/src/pages/settings/SettingsPage.tsx
@@ -76,7 +76,7 @@ const SettingsPage = () => {
 		},
 		{
 			title: 'Abonnement Premium',
-			href: '/app/settings/subscription',
+			href: '/app/subscription',
 			icon: CreditCard,
 			description: 'Plan, facturation, avantages',
 		},

--- a/ineat-frontend/src/pages/subscription/SubscriptionPage.tsx
+++ b/ineat-frontend/src/pages/subscription/SubscriptionPage.tsx
@@ -16,7 +16,8 @@ import {
   Users, 
   Shield,
   Zap,
-  Star
+  Star,
+  CreditCard
 } from 'lucide-react';
 import { useUser } from '@/hooks/useAuth';
 import type { SubscriptionPlan as UserSubscriptionPlan } from '@/schemas';
@@ -131,6 +132,7 @@ export const SubscriptionPage: React.FC = () => {
   const navigate = useNavigate();
   const { data: user, isLoading: userLoading } = useUser();
   const [isProcessing, setIsProcessing] = useState(false);
+  const [isPortalOpening, setIsPortalOpening] = useState(false);
 
   const currentPlan: UserSubscriptionPlan = user?.subscriptionPlan || 'FREE';
   const effectivePlan = user?.effectivePlan || 'FREE';
@@ -140,6 +142,9 @@ export const SubscriptionPage: React.FC = () => {
     currentPlan === 'TRIAL' && user?.subscriptionStatus === 'EXPIRED';
   const capabilities = user?.capabilities;
   const trialEndsAt = formatDate(user?.trialEndsAt);
+  const currentPeriodEndsAt = formatDate(user?.currentPeriodEndsAt);
+  const isCancelledAtPeriodEnd =
+    user?.subscriptionStatus === 'CANCELLED' && Boolean(user?.cancelAtPeriodEnd);
   const aiQuotaReached = Boolean(
     capabilities &&
       isPremium &&
@@ -186,6 +191,23 @@ export const SubscriptionPage: React.FC = () => {
 
   const handleStartTrial = () => {
     toast.info('L’essai gratuit sera activé dans une prochaine étape.');
+  };
+
+  const handleManageSubscription = async () => {
+    setIsPortalOpening(true);
+
+    try {
+      const portalSession = await billingService.createPortalSession();
+      window.location.assign(portalSession.url);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Impossible d'ouvrir la gestion de l'abonnement.";
+      toast.error(errorMessage);
+    } finally {
+      setIsPortalOpening(false);
+    }
   };
 
   /**
@@ -262,6 +284,17 @@ export const SubscriptionPage: React.FC = () => {
       );
     }
 
+    if (isCancelledAtPeriodEnd) {
+      return (
+        <Alert className="mb-8 border-orange-200 bg-orange-50">
+          <Crown className="size-4 text-orange-700" />
+          <AlertDescription className="text-orange-800">
+            Votre abonnement restera actif jusqu’au {currentPeriodEndsAt ?? 'terme de la période payée'}.
+          </AlertDescription>
+        </Alert>
+      );
+    }
+
     if (!isPremium) {
       return (
         <Alert className="mb-8">
@@ -274,6 +307,42 @@ export const SubscriptionPage: React.FC = () => {
     }
 
     return null;
+  };
+
+  const renderSubscriptionManagement = () => {
+    if (!isPremium || isTrial) return null;
+
+    return (
+      <Card className="mb-8">
+        <CardContent className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Gestion de l’abonnement</h2>
+            <p className="text-sm text-muted-foreground">
+              {isCancelledAtPeriodEnd
+                ? `Premium reste actif jusqu’au ${currentPeriodEndsAt ?? 'terme de la période payée'}.`
+                : `Facturation ${user?.billingInterval === 'YEARLY' ? 'annuelle' : 'mensuelle'} gérée par Stripe.`}
+            </p>
+          </div>
+          <Button
+            onClick={handleManageSubscription}
+            disabled={isPortalOpening || isProcessing}
+            className="gap-2"
+          >
+            {isPortalOpening ? (
+              <>
+                <div className="animate-spin size-4 border-2 border-current border-t-transparent rounded-full" />
+                Ouverture...
+              </>
+            ) : (
+              <>
+                <CreditCard className="size-4" />
+                Gérer mon abonnement
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    );
   };
 
   const renderQuotaSummary = () => {
@@ -519,6 +588,7 @@ export const SubscriptionPage: React.FC = () => {
         {renderHeader()}
         {renderPlanStatus()}
         {renderQuotaSummary()}
+        {renderSubscriptionManagement()}
         {renderPremiumHighlights()}
         
         {/* Plans d'abonnement */}

--- a/ineat-frontend/src/routeTree.gen.ts
+++ b/ineat-frontend/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as AppInventoryIndexRouteImport } from './routes/app/inventory/in
 import { Route as AppBudgetIndexRouteImport } from './routes/app/budget/index'
 import { Route as AppAdminIndexRouteImport } from './routes/app/admin/index'
 import { Route as AppSubscriptionSuccessRouteImport } from './routes/app/subscription/success'
+import { Route as AppSettingsSubscriptionRouteImport } from './routes/app/settings/subscription'
 import { Route as AppRecipesSuggestionsRouteImport } from './routes/app/recipes/suggestions'
 import { Route as AppRecipesRecipeIdRouteImport } from './routes/app/recipes/$recipeId'
 import { Route as AppInventoryProductIdRouteImport } from './routes/app/inventory/$productId'
@@ -122,6 +123,11 @@ const AppSubscriptionSuccessRoute = AppSubscriptionSuccessRouteImport.update({
   path: '/subscription/success',
   getParentRoute: () => AppRouteRoute,
 } as any)
+const AppSettingsSubscriptionRoute = AppSettingsSubscriptionRouteImport.update({
+  id: '/settings/subscription',
+  path: '/settings/subscription',
+  getParentRoute: () => AppRouteRoute,
+} as any)
 const AppRecipesSuggestionsRoute = AppRecipesSuggestionsRouteImport.update({
   id: '/recipes/suggestions',
   path: '/recipes/suggestions',
@@ -192,6 +198,7 @@ export interface FileRoutesByFullPath {
   '/app/inventory/$productId': typeof AppInventoryProductIdRoute
   '/app/recipes/$recipeId': typeof AppRecipesRecipeIdRoute
   '/app/recipes/suggestions': typeof AppRecipesSuggestionsRoute
+  '/app/settings/subscription': typeof AppSettingsSubscriptionRoute
   '/app/subscription/success': typeof AppSubscriptionSuccessRoute
   '/app/admin': typeof AppAdminIndexRoute
   '/app/budget': typeof AppBudgetIndexRoute
@@ -220,6 +227,7 @@ export interface FileRoutesByTo {
   '/app/inventory/$productId': typeof AppInventoryProductIdRoute
   '/app/recipes/$recipeId': typeof AppRecipesRecipeIdRoute
   '/app/recipes/suggestions': typeof AppRecipesSuggestionsRoute
+  '/app/settings/subscription': typeof AppSettingsSubscriptionRoute
   '/app/subscription/success': typeof AppSubscriptionSuccessRoute
   '/app/admin': typeof AppAdminIndexRoute
   '/app/budget': typeof AppBudgetIndexRoute
@@ -251,6 +259,7 @@ export interface FileRoutesById {
   '/app/inventory/$productId': typeof AppInventoryProductIdRoute
   '/app/recipes/$recipeId': typeof AppRecipesRecipeIdRoute
   '/app/recipes/suggestions': typeof AppRecipesSuggestionsRoute
+  '/app/settings/subscription': typeof AppSettingsSubscriptionRoute
   '/app/subscription/success': typeof AppSubscriptionSuccessRoute
   '/app/admin/': typeof AppAdminIndexRoute
   '/app/budget/': typeof AppBudgetIndexRoute
@@ -282,6 +291,7 @@ export interface FileRouteTypes {
     | '/app/inventory/$productId'
     | '/app/recipes/$recipeId'
     | '/app/recipes/suggestions'
+    | '/app/settings/subscription'
     | '/app/subscription/success'
     | '/app/admin'
     | '/app/budget'
@@ -310,6 +320,7 @@ export interface FileRouteTypes {
     | '/app/inventory/$productId'
     | '/app/recipes/$recipeId'
     | '/app/recipes/suggestions'
+    | '/app/settings/subscription'
     | '/app/subscription/success'
     | '/app/admin'
     | '/app/budget'
@@ -340,6 +351,7 @@ export interface FileRouteTypes {
     | '/app/inventory/$productId'
     | '/app/recipes/$recipeId'
     | '/app/recipes/suggestions'
+    | '/app/settings/subscription'
     | '/app/subscription/success'
     | '/app/admin/'
     | '/app/budget/'
@@ -486,6 +498,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSubscriptionSuccessRouteImport
       parentRoute: typeof AppRouteRoute
     }
+    '/app/settings/subscription': {
+      id: '/app/settings/subscription'
+      path: '/settings/subscription'
+      fullPath: '/app/settings/subscription'
+      preLoaderRoute: typeof AppSettingsSubscriptionRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
     '/app/recipes/suggestions': {
       id: '/app/recipes/suggestions'
       path: '/recipes/suggestions'
@@ -589,6 +608,7 @@ interface AppRouteRouteChildren {
   AppInventoryProductIdRoute: typeof AppInventoryProductIdRoute
   AppRecipesRecipeIdRoute: typeof AppRecipesRecipeIdRoute
   AppRecipesSuggestionsRoute: typeof AppRecipesSuggestionsRoute
+  AppSettingsSubscriptionRoute: typeof AppSettingsSubscriptionRoute
   AppSubscriptionSuccessRoute: typeof AppSubscriptionSuccessRoute
   AppAdminIndexRoute: typeof AppAdminIndexRoute
   AppBudgetIndexRoute: typeof AppBudgetIndexRoute
@@ -613,6 +633,7 @@ const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppInventoryProductIdRoute: AppInventoryProductIdRoute,
   AppRecipesRecipeIdRoute: AppRecipesRecipeIdRoute,
   AppRecipesSuggestionsRoute: AppRecipesSuggestionsRoute,
+  AppSettingsSubscriptionRoute: AppSettingsSubscriptionRoute,
   AppSubscriptionSuccessRoute: AppSubscriptionSuccessRoute,
   AppAdminIndexRoute: AppAdminIndexRoute,
   AppBudgetIndexRoute: AppBudgetIndexRoute,

--- a/ineat-frontend/src/routes/app/settings/subscription.tsx
+++ b/ineat-frontend/src/routes/app/settings/subscription.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import SubscriptionPage from '@/pages/subscription/SubscriptionPage';
+
+export const Route = createFileRoute('/app/settings/subscription')({
+	component: SubscriptionPage,
+});

--- a/ineat-frontend/src/schemas/base.ts
+++ b/ineat-frontend/src/schemas/base.ts
@@ -23,6 +23,9 @@ export const SubscriptionStatusSchema = z.enum([
 ]);
 export type SubscriptionStatus = z.infer<typeof SubscriptionStatusSchema>;
 
+export const BillingIntervalSchema = z.enum(['MONTHLY', 'YEARLY']);
+export type BillingInterval = z.infer<typeof BillingIntervalSchema>;
+
 export const EffectivePlanSchema = z.enum(['FREE', 'PREMIUM']);
 export type EffectivePlan = z.infer<typeof EffectivePlanSchema>;
 

--- a/ineat-frontend/src/schemas/user.ts
+++ b/ineat-frontend/src/schemas/user.ts
@@ -9,6 +9,7 @@ import {
 	UserRoleSchema,
 	SubscriptionPlanSchema,
 	SubscriptionStatusSchema,
+	BillingIntervalSchema,
 	EffectivePlanSchema,
 } from './base';
 import {
@@ -61,6 +62,8 @@ export const UserSchema = z
 		trialEndsAt: z.string().datetime().nullable().optional(),
 		currentPeriodStartedAt: z.string().datetime().nullable().optional(),
 		currentPeriodEndsAt: z.string().datetime().nullable().optional(),
+		billingInterval: BillingIntervalSchema.nullable().optional(),
+		cancelAtPeriodEnd: z.boolean().default(false),
 		effectivePlan: EffectivePlanSchema.default('FREE'),
 		capabilities: AccessCapabilitiesSchema.default(
 			DEFAULT_ACCESS_CAPABILITIES

--- a/ineat-frontend/src/services/billingService.ts
+++ b/ineat-frontend/src/services/billingService.ts
@@ -13,12 +13,24 @@ type CheckoutSession = {
 	url: string;
 };
 
+type PortalSession = {
+	id: string;
+	url: string;
+};
+
 export const billingService = {
 	async createCheckoutSession(interval: BillingInterval) {
 		const response = await apiClient.post<ApiSuccessResponse<CheckoutSession>>(
 			'/billing/checkout',
 			{ interval }
 		);
+
+		return response.data;
+	},
+
+	async createPortalSession() {
+		const response =
+			await apiClient.post<ApiSuccessResponse<PortalSession>>('/billing/portal');
 
 		return response.data;
 	},


### PR DESCRIPTION
## Summary
- Add secured backend endpoint `POST /billing/portal` to create Stripe Customer Portal sessions.
- Add subscription management CTA on the Premium subscription page.
- Add `/app/settings/subscription` route alias.
- Update Settings subscription link to point to `/app/subscription`.

## Tests
- `pnpm exec jest billing.service.spec.ts --watchman=false`
- `pnpm run build` backend
- `pnpm run lint:check` backend
- `pnpm run build` frontend
- `pnpm run lint` frontend